### PR TITLE
Archive upload verify, remove redundant variables

### DIFF
--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -50,29 +50,29 @@ workflows:
                 - verify_archive_dir
 
             verify_archive_dir:
-             action: arteria-packs.poll_status-archive
-             input:
-               url: <% $.archive_verify_base_url %>/verify
-               body: <% $.verify_body %>
-               verify_ssl_cert: True
-               irma_mode: False
-               timeout: 86400 # 24h timeout
-             publish:
-               archive_path: <% task(verify_archive_dir).result.result.response_from_start.response.path %>
-               archive_host: <% task(verify_archive_dir).result.result.response_from_start.response.host %>
-               archive_description: <% task(verify_archive_dir).result.result.response_from_start.response.description %>
-             on-success:
-               - mark_verify_ok_in_db
+              action: arteria-packs.poll_status-archive
+              input:
+                url: <% $.archive_verify_base_url %>/verify
+                body: <% $.verify_body %>
+                verify_ssl_cert: True
+                irma_mode: False
+                timeout: 86400 # 24h timeout
+              publish:
+                archive_path: <% task(verify_archive_dir).result.result.response_from_start.response.path %>
+                archive_host: <% task(verify_archive_dir).result.result.response_from_start.response.host %>
+                archive_description: <% task(verify_archive_dir).result.result.response_from_start.response.description %>
+              on-success:
+                - mark_verify_ok_in_db
 
             mark_verify_ok_in_db:
-                action: core.http
-                input:
-                  url: <% $.archive_db_base_url %>/verification
-                  body: '{ "description": "<% $.description %>", "host": "<% $.host %>", "path": "<% $.archive_path %>" }'
-                  method: "POST"
-                  timeout: 60
-                on-success:
-                  - notify_success_on_slack
+              action: core.http
+              input:
+                url: <% $.archive_db_base_url %>/verification
+                body: '{ "description": "<% $.description %>", "host": "<% $.host %>", "path": "<% $.archive_path %>" }'
+                method: "POST"
+                timeout: 60
+              on-success:
+                - notify_success_on_slack
 
             notify_success_on_slack:
               action: arteria-packs.post_to_slack
@@ -87,13 +87,13 @@ workflows:
             ## NOTIFIER START ###
 
             notify_failure_on_slack:
-               action: arteria-packs.post_to_slack
-               input:
-                 user: 'I, Archivian'
-                 emoji_icon: ':robot_face:'
-                 channel: <% $.archive_status_slack_channel %>
-                 message: 'Unfortunately an error occurred when trying to verify archive `<% $.archive %>` uploaded from `<% $.host %>`. You can see more details by running: `st2 execution get <% env().st2_execution_id %>`'
-               on-complete:
-                 - fail
+              action: arteria-packs.post_to_slack
+              input:
+                user: 'I, Archivian'
+                emoji_icon: ':robot_face:'
+                channel: <% $.archive_status_slack_channel %>
+                message: 'Unfortunately an error occurred when trying to verify archive `<% $.archive %>` uploaded from `<% $.host %>`. You can see more details by running: `st2 execution get <% env().st2_execution_id %>`'
+              on-complete:
+                - fail
 
             ### NOTIFIER END ###

--- a/actions/workflows/archive_verify_specific.yaml
+++ b/actions/workflows/archive_verify_specific.yaml
@@ -59,8 +59,6 @@ workflows:
                 timeout: 86400 # 24h timeout
               publish:
                 archive_path: <% task(verify_archive_dir).result.result.response_from_start.response.path %>
-                archive_host: <% task(verify_archive_dir).result.result.response_from_start.response.host %>
-                archive_description: <% task(verify_archive_dir).result.result.response_from_start.response.description %>
               on-success:
                 - mark_verify_ok_in_db
 
@@ -80,7 +78,7 @@ workflows:
                 user: "I, Archivian"
                 emoji_icon: ":robot_face:"
                 channel: <% $.archive_status_slack_channel %>
-                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>` with description `<% $.archive_description %>` on `<% $.archive_host %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
+                message: "Successfully verified MD5 sums for archive `<% $.archive_path %>` with description `<% $.description %>` on `<% $.host %>`. See details with `st2 execution get <% env().st2_execution_id %>`"
 
             ### END TSM ARCHIVE VERIFY ###
 


### PR DESCRIPTION
**What problems does this PR solve?**
The task verify_archive_dir failed because it tried to publish variables that were never returned. Redundant variables were removed and wanted values are now feteched from other variables instead.

**How has the changes been tested?**
This is not tested. But the changes should do no harm since redundant variables only were used in a printed message.   

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data
